### PR TITLE
Refactor functional wrappers

### DIFF
--- a/dune/gdt/assembler/system.hh
+++ b/dune/gdt/assembler/system.hh
@@ -373,7 +373,6 @@ public:
     return *this;
   } // ... append(...)
 
-
   template <class V, class R>
   ThisType& append(const LocalVolumeFunctionalInterface<TestSpaceType, R>& local_volume_functional,
                    XT::LA::VectorInterface<V, R>& vector,
@@ -384,7 +383,6 @@ public:
             test_space_, where, local_volume_functional, vector.as_imp()));
     return *this;
   } // ... append(...)
-
 
   template <class V, class R>
   ThisType&

--- a/dune/gdt/assembler/system.hh
+++ b/dune/gdt/assembler/system.hh
@@ -374,7 +374,7 @@ public:
   } // ... append(...)
 
   template <class V, class R>
-  ThisType& append(const LocalVolumeFunctionalInterface<TestSpaceType, R>& local_volume_functional,
+  ThisType& append(const LocalVolumeFunctionalInterface<TestBaseType, R>& local_volume_functional,
                    XT::LA::VectorInterface<V, R>& vector,
                    const ApplyOnWhichEntity* where = new XT::Grid::ApplyOn::AllEntities<GridLayerType>())
   {

--- a/dune/gdt/functionals/base.hh
+++ b/dune/gdt/functionals/base.hh
@@ -70,6 +70,7 @@ class VectorFunctionalBase
 public:
   typedef internal::VectorFunctionalBaseTraits<VectorImp, SpaceImp, GridLayerImp, FieldImp> Traits;
   typedef typename BaseAssemblerType::AnsatzSpaceType SpaceType;
+  typedef typename SpaceType::BaseFunctionSetType TestBaseType;
   using typename BaseAssemblerType::GridLayerType;
   typedef VectorImp VectorType;
   using typename BaseFunctionalType::FieldType;
@@ -125,7 +126,7 @@ public:
   using BaseAssemblerType::append;
 
   ThisType& append(
-      const LocalVolumeFunctionalInterface<SpaceType, FieldType>& local_volume_functional,
+      const LocalVolumeFunctionalInterface<TestBaseType, FieldType>& local_volume_functional,
       const XT::Grid::ApplyOn::WhichEntity<GridLayerType>* where = new XT::Grid::ApplyOn::AllEntities<GridLayerType>())
   {
     this->append(local_volume_functional, vector_.access(), where);


### PR DESCRIPTION
The problem was not the type in `L2VolumeVectorFunctional` (there you correctly used the `typename Space::BaseFunctionSetType` as 2nd argument to `LocalVolumeIntegralFunctional`), but rather the `append` methods in `VectorFunctionalBase` and `SystemAssembler`, where you still had the space as second argument (and not the basis of the space) to `LocalVolumeFunctionalInterface`.